### PR TITLE
lint: Add rule to exclude linting URLs that exceed the line length limit.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ issues:
   exclude-rules:
     - linters:
         - revive
-      source: "^// \\[.+\\]: https?://.+"
+      source: "^\\s*// (?:\\[.+\\]: )?https?://.+"
 
 linters:
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,10 @@ output:
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+  exclude-rules:
+    - linters:
+        - revive
+      source: "^// \\[.+\\]: https?://.+"
 
 linters:
   disable-all: true

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -8,8 +8,6 @@
 // [CLP]: https://github.com/y-scope/clp
 // [Uber blog]: https://www.uber.com/blog/reducing-logging-cost-by-two-orders-of-magnitude-using-clp/
 // [log viewer]: https://github.com/y-scope/yscope-log-viewer
-//
-//nolint:revive
 package ir
 
 /*


### PR DESCRIPTION
# Description
Prior to this PR long lines caused by URLs skipped linting by adding a `nolint` comment. However, this will disable linting for the entire block, which can include code. This exclude rule will only match on source lines with the regex pattern `"^\\s*// (?:\\[.+\\]: )?https?://.+"` which is meant to only match (possibly indented) comments:
* starting with a URL: `// https://very.long.url`
* starting with a markdown-style tagged URL: `// [url reference] https://very.long.url`

# Validation performed
Manually tested on various comments with urls.
Additional tests performed by @davemarco on cases found in y-scope/fluent-bit-clp#3.

